### PR TITLE
feat(vultr-csi): update the chart from v0.3.0 to v0.11.0

### DIFF
--- a/vultr-csi/Chart.yaml
+++ b/vultr-csi/Chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: v2
 name: vultr-csi
-version: 2.0.0
+version: 3.0.0
 description:  A Helm chart for Vultr's Container Storage Interface.
 type: application
-home: https://github.com/vultr/vultr-csi
+home: https://git.udg.pub/udg.pub/vultr-helm-charts
 sources:
-    - https://github.com/vultr/vultr-csi
+    - https://git.udg.pub/udg.pub/vultr-helm-charts
 maintainers:
   - name: David Dymko
+  - name: Piotr Szczurkowski
 icon: https://helm-charts.ewr1.vultrobjects.com/icons/vultr.svg
-appVersion: "v0.3.0"
+appVersion: "v0.11.0"

--- a/vultr-csi/templates/csi_controller.yaml
+++ b/vultr-csi/templates/csi_controller.yaml
@@ -18,12 +18,13 @@ spec:
       serviceAccountName: csi-vultr-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.4
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
           args:
             - "--volume-name-prefix=pvc"
             - "--volume-name-uuid-length=16"
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -32,7 +33,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -40,6 +41,20 @@ spec:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
+            - "--v=5"
+            - "--handle-volume-inuse-error=false"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/vultr-csi/templates/csi_node.yaml
+++ b/vultr-csi/templates/csi_node.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -126,3 +126,35 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch" ]
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-vultr-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-vultr-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-vultr-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-vultr-resizer-role

--- a/vultr-csi/templates/storageclass.yaml
+++ b/vultr-csi/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: block.csi.vultr.com
@@ -12,9 +12,10 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: vultr-block-storage
   namespace: kube-system
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: block.csi.vultr.com
+allowVolumeExpansion: true
+parameters:
+  block_type: high_perf
 
 ---
 kind: StorageClass
@@ -23,4 +24,32 @@ metadata:
   name: vultr-block-storage-retain
   namespace: kube-system
 provisioner: block.csi.vultr.com
+allowVolumeExpansion: true
 reclaimPolicy: Retain
+parameters:
+  block_type: high_perf
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vultr-block-storage-hdd
+  namespace: kube-system
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true
+provisioner: block.csi.vultr.com
+parameters:
+  block_type: storage_opt
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vultr-block-storage-hdd-retain
+  namespace: kube-system
+allowVolumeExpansion: true
+provisioner: block.csi.vultr.com
+reclaimPolicy: Retain
+parameters:
+  block_type: storage_opt

--- a/vultr-csi/values.yaml
+++ b/vultr-csi/values.yaml
@@ -2,4 +2,4 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-vultrCSIRelease: "v0.3.0"
+vultrCSIRelease: "v0.11.0"


### PR DESCRIPTION
## Description
Bump the vultr-csi chart version to `3.0.0` and update the release to `v0.11.0`.
The changes were tested on the latest k3s kubernetes cluster.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
